### PR TITLE
Fix leaderboard API URL joining

### DIFF
--- a/index.html
+++ b/index.html
@@ -966,8 +966,13 @@ function validateUsername(name){
 
 function apiUrl(path){
   if (!API_BASE) return path;
-  const base = API_BASE.endsWith('/') ? API_BASE.slice(0,-1) : API_BASE;
-  return `${base}${path}`;
+  try{
+    const baseUrl = new URL(API_BASE, window.location.href);
+    return new URL(path, baseUrl).toString();
+  }catch(err){
+    console.warn('Invalid API base URL', API_BASE, err);
+    return path;
+  }
 }
 
 async function refreshLeaderboard(opts){


### PR DESCRIPTION
## Summary
- fix the leaderboard apiUrl helper to build URLs with the URL constructor so bases with subpaths work
- log and gracefully fall back to relative requests when an invalid API base is supplied

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d7447ff0e88320a13f1e8fc6523abe