### PR TITLE
Include fragment credentials in leaderboard API requests

### DIFF
--- a/index.html
+++ b/index.html
@@ -1200,7 +1200,15 @@ function apiUrl(path){
 
     const mergedSearch = new URLSearchParams(baseUrl.search);
     const extraSearch = new URLSearchParams(dummy.search);
+    const baseHashParams = new URLSearchParams(baseUrl.hash ? baseUrl.hash.replace(/^#/, '') : '');
+    const dummyHashParams = new URLSearchParams(dummy.hash ? dummy.hash.replace(/^#/, '') : '');
     for (const [key, value] of extraSearch.entries()){
+      mergedSearch.append(key, value);
+    }
+    for (const [key, value] of baseHashParams.entries()){
+      mergedSearch.append(key, value);
+    }
+    for (const [key, value] of dummyHashParams.entries()){
       mergedSearch.append(key, value);
     }
     const searchString = mergedSearch.toString();


### PR DESCRIPTION
## Summary
- parse API base and path fragments with URLSearchParams when building request URLs
- merge fragment parameters into the computed query string so credential pairs are sent with every call

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d751bd85648320aa289ffce4a55f58