### PR TITLE
Fix leaderboard pagination and add level & coin columns

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -38,6 +38,8 @@
   .leaderboardRow{display:flex;align-items:center;gap:10px;width:100%;flex-wrap:wrap;color:#f9fafb;font-size:14px}
   .lbRank{font-weight:700;min-width:48px}
   .lbName{flex:1;font-weight:600;word-break:break-word}
+  .lbLevel{min-width:72px;text-align:right;font-variant-numeric:tabular-nums}
+  .lbCoins{min-width:98px;text-align:right;font-variant-numeric:tabular-nums}
   .lbScore{min-width:120px;text-align:right;font-variant-numeric:tabular-nums}
   .lbDate{min-width:132px;text-align:right;font-size:12px;opacity:.8;font-variant-numeric:tabular-nums}
   .leaderboardItem.selfEntry{box-shadow:0 0 0 2px rgba(250,204,21,.55)}


### PR DESCRIPTION
## Summary
- make the leaderboard loader try multiple pagination strategies so up to 100 ranks are retrieved reliably
- surface each entry's level and coins alongside the score in the overlay

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d89887b66c832082baa812054d8890