### PR TITLE
Adjust pre-game overlay sizing for accessibility

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -201,18 +201,21 @@
   /* ガチャ & コレクション オーバーレイ */
   .overlay{
     position:fixed; inset:0; background:rgba(0,0,0,.6); display:none; z-index:20;
-    align-items:center; justify-content:center; padding:16px;
+    align-items:center; justify-content:center; padding:clamp(12px,4vh,28px) 16px;
+    overflow-y:auto;
   }
   .cardWrap{
     width:min(94vw,820px); background:#111827; color:#fff; border-radius:16px; padding:16px;
-    box-shadow:0 8px 32px rgba(0,0,0,.45); text-align:left;
+    box-shadow:0 8px 32px rgba(0,0,0,.45); text-align:left; max-height:calc(100vh - clamp(24px,8vh,56px));
+    display:flex; flex-direction:column; gap:12px;
   }
   .cardHeader{display:flex;justify-content:space-between;align-items:center;margin-bottom:8px}
   .cardHeader h2{margin:0;font-size:20px}
-  .cardBody{min-height:160px;border:1px solid #374151;border-radius:12px;padding:12px;background:#0b1220}
-  .preGameCard{width:min(96vw,860px)}
-  .preGameBody{display:grid;gap:16px;min-height:0}
-  .preGameList{display:flex;flex-wrap:wrap;gap:10px;overflow-x:auto;padding-bottom:4px;max-height:220px}
+  .cardBody{min-height:160px;border:1px solid #374151;border-radius:12px;padding:12px;background:#0b1220;overflow:auto}
+  .preGameCard{width:min(96vw,860px);max-height:min(92vh,720px);gap:10px;padding:18px}
+  .preGameCard .cardBody{flex:1;min-height:0}
+  .preGameBody{display:grid;grid-template-columns:minmax(0,0.95fr) minmax(0,0.8fr);gap:14px;min-height:0}
+  .preGameList{display:grid;grid-template-columns:repeat(auto-fit,minmax(110px,1fr));gap:10px;overflow-y:auto;max-height:240px;padding-right:4px}
   .preGameList::-webkit-scrollbar{height:6px}
   .preGameList::-webkit-scrollbar-thumb{background:rgba(148,163,184,.35);border-radius:999px}
   .preCharCard{appearance:none;border:1px solid rgba(148,163,184,.25);border-radius:14px;padding:12px;min-width:112px;min-height:112px;background:rgba(30,41,59,.65);color:#fff;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:6px;font:inherit;cursor:pointer;transition:transform .16s ease,box-shadow .16s ease,border-color .16s ease}
@@ -221,13 +224,13 @@
   .preCharCard .rar{font-size:12px;opacity:.75}
   .preCharCard.isSelected{border-color:#60a5fa;box-shadow:0 0 0 2px rgba(96,165,250,.65),0 10px 22px rgba(37,99,235,.35);transform:translateY(-2px)}
   .preGameEmpty{padding:12px 0;color:#cbd5f5;font-size:14px;opacity:.8}
-  .preGameInfo{display:flex;flex-direction:column;gap:12px;background:rgba(15,23,42,.55);border-radius:14px;padding:14px 16px;border:1px solid rgba(148,163,184,.24)}
-  .preGameSummary{font-size:18px;font-weight:700;display:flex;align-items:center;gap:8px}
-  .preGameUlt{margin:0;font-size:14px;line-height:1.6}
+  .preGameInfo{display:flex;flex-direction:column;gap:10px;background:rgba(15,23,42,.55);border-radius:14px;padding:12px 14px;border:1px solid rgba(148,163,184,.24)}
+  .preGameSummary{font-size:17px;font-weight:700;display:flex;align-items:center;gap:8px}
+  .preGameUlt{margin:0;font-size:13px;line-height:1.6}
   .preGameSpecial{display:flex;flex-wrap:wrap;gap:8px}
   .preGameSpecial span{background:rgba(96,165,250,.22);color:#bfdbfe;padding:4px 10px;border-radius:999px;font-size:12px;letter-spacing:.05em}
-  .preGameStats{list-style:none;margin:0;padding:0;display:grid;gap:6px}
-  .preGameStats li{display:flex;justify-content:space-between;gap:10px;font-size:14px}
+  .preGameStats{list-style:none;margin:0;padding:0;display:grid;gap:6px;font-size:13px}
+  .preGameStats li{display:flex;justify-content:space-between;gap:10px}
   .preGameStats span.value{font-variant-numeric:tabular-nums;font-weight:600}
   .preGameActions{justify-content:center}
   #leaderboardOverlay .cardBody{


### PR DESCRIPTION
## Summary
- allow overlays to scroll and cap the pre-game card height so the start button stays on screen
- tighten spacing in the character info panel and switch the roster to a responsive grid for a more compact layout

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d8c838536c83209dfcdcf84fd6b19e