### PR TITLE
Adjust HUD layout and touch controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,6 +57,16 @@
     </div>
     <div id="charInfo" class="muted">CHAR: -</div>
     <canvas id="cv" width="900" height="430"></canvas>
+    <div id="startScreen" class="startScreen" aria-hidden="false">
+      <div class="startScreenInner">
+        <p class="startScreenTitle">走る準備はいい？</p>
+        <div class="primaryBtns">
+          <button id="start">スタート</button>
+          <button id="restart" class="secondary" style="display:none">リスタート</button>
+          <button id="howto" class="ghost">遊び方</button>
+        </div>
+      </div>
+    </div>
     <div id="touchControls" class="actionBar" aria-hidden="true">
       <button id="jumpBtn" class="touchBtn touchJump" aria-label="ジャンプ">ジャンプ</button>
       <button id="attackBtn" class="touchBtn touchAttack" aria-label="攻撃">攻撃</button>
@@ -64,11 +74,6 @@
     </div>
 
     <div id="btns">
-      <div class="primaryBtns">
-        <button id="start">スタート</button>
-        <button id="restart" class="secondary" style="display:none">リスタート</button>
-        <button id="howto" class="ghost">遊び方</button>
-      </div>
       <div class="secondaryBtns" aria-label="サブメニュー">
         <button id="gachaOpen" class="warn" disabled>ガチャ(10)</button>
         <button id="gacha10" class="warn" disabled>10連(100)</button>

--- a/index.html
+++ b/index.html
@@ -22,26 +22,63 @@
   </section>
 
   <div id="wrap">
-    <div id="hud" class="hudOverlay">読み込み中…</div>
+    <div id="hud" class="hudOverlay">
+      <div class="hudRow hudRowPrimary">
+        <div class="hudItem hudLife">
+          <span class="hudLabel">ライフ</span>
+          <span class="hudValue hudHearts">-</span>
+          <span class="hudGauge">必殺 0%</span>
+        </div>
+        <div class="hudItem hudTime">
+          <span class="hudLabel">残り時間</span>
+          <span class="hudValue">-</span>
+        </div>
+        <div class="hudItem hudScore">
+          <span class="hudLabel">スコア</span>
+          <span class="hudValue hudScoreValue">-</span>
+        </div>
+      </div>
+      <div class="hudRow hudRowSecondary">
+        <div class="hudItem hudStage">
+          <span class="hudLabel">ステージ</span>
+          <span class="hudValue">-</span>
+          <span class="hudSub">Lv.-</span>
+        </div>
+        <div class="hudItem hudCoins">
+          <span class="hudLabel">コイン</span>
+          <span class="hudValue">-</span>
+        </div>
+        <div class="hudItem hudBest">
+          <span class="hudLabel">ベスト</span>
+          <span class="hudValue">-</span>
+        </div>
+      </div>
+      <div class="hudEffects isHidden"></div>
+    </div>
     <div id="charInfo" class="muted">CHAR: -</div>
     <canvas id="cv" width="900" height="430"></canvas>
+    <div id="touchControls" class="actionBar" aria-hidden="true">
+      <button id="jumpBtn" class="touchBtn touchJump" aria-label="ジャンプ">ジャンプ</button>
+      <button id="attackBtn" class="touchBtn touchAttack" aria-label="攻撃">攻撃</button>
+      <button id="ultBtn" class="touchBtn touchUlt" aria-label="必殺技">必殺技</button>
+    </div>
+
     <div id="btns">
-      <button id="start">スタート</button>
-      <button id="restart" class="secondary" style="display:none">リスタート</button>
-      <button id="howto" class="ghost">遊び方</button>
-      <button id="gachaOpen" class="warn" disabled>ガチャ(10)</button>
-      <button id="gacha10" class="warn" disabled>10連(100)</button>
-      <button id="collection" class="ghost">コレクション</button>
-      <button id="codexBtn" class="ghost">図鑑</button>
-      <button id="leaderboardBtn" class="ghost">ランキング</button>
-      <button id="commentBtn" class="ghost">コメント</button>
+      <div class="primaryBtns">
+        <button id="start">スタート</button>
+        <button id="restart" class="secondary" style="display:none">リスタート</button>
+        <button id="howto" class="ghost">遊び方</button>
+      </div>
+      <div class="secondaryBtns" aria-label="サブメニュー">
+        <button id="gachaOpen" class="warn" disabled>ガチャ(10)</button>
+        <button id="gacha10" class="warn" disabled>10連(100)</button>
+        <button id="collection" class="ghost">コレクション</button>
+        <button id="codexBtn" class="ghost">図鑑</button>
+        <button id="leaderboardBtn" class="ghost">ランキング</button>
+        <button id="commentBtn" class="ghost">コメント</button>
+      </div>
     </div>
     <p class="muted controls"><strong>操作ヒント：</strong>画面左側タップ/クリック＝ジャンプ、右側＝攻撃、右長押し or 右下の<strong>必殺</strong>ボタン＝必殺技（ゲージ100%時）。</p>
-  </div>
-
-  <div id="touchControls">
-    <button id="jumpBtn" class="touchBtn" aria-label="ジャンプ">ジャンプ</button>
-    <button id="ultBtn" class="touchBtn touchUlt" aria-label="必殺">必殺</button>
   </div>
 
   <!-- プレゲーム：キャラ選択 -->

--- a/main.js
+++ b/main.js
@@ -9,6 +9,7 @@ const c = cv.getContext('2d');
 const hud = document.getElementById('hud');
 const btnStart = document.getElementById('start');
 const btnRestart = document.getElementById('restart');
+const startScreen = document.getElementById('startScreen');
 const touchControls = document.getElementById('touchControls');
 const btnUlt = document.getElementById('ultBtn');
 const btnAttack = document.getElementById('attackBtn');
@@ -494,6 +495,12 @@ function setHUD(remainMs){
 
   btnGacha.disabled = coins < 10;
   btnGacha10.disabled = coins < 100;
+}
+
+function setStartScreenVisible(show){
+  if (!startScreen) return;
+  startScreen.classList.toggle('isHidden', !show);
+  startScreen.setAttribute('aria-hidden', show ? 'false' : 'true');
 }
 
 function describeUlt(key){
@@ -1427,6 +1434,7 @@ function startGame(){
   guardReadyTime = 0;
   resetPlayerAnimation();
   btnStart.style.display='none'; btnRestart.style.display='none';
+  setStartScreenVisible(false);
   t0=now(); gameOn=true;
   lastItem=lastEnemy=lastPower=lastShot=t0;
   currentStats = getEffectiveStats(currentCharKey);
@@ -1450,6 +1458,7 @@ function endGame(){
   updateBestScore(finalResult.score);
   setHUD(0);
   showResultOverlay(finalResult);
+  setStartScreenVisible(true);
   c.textAlign='start'; btnRestart.style.display='inline-block';
   setTimeout(()=>{
     try {
@@ -1520,5 +1529,6 @@ HowtoModule?.init?.({
 
 setHUD(GAME_TIME);
 updateCharInfo();
+setStartScreenVisible(true);
 LeaderboardModule?.load?.(false);
 })();

--- a/main.js
+++ b/main.js
@@ -11,6 +11,7 @@ const btnStart = document.getElementById('start');
 const btnRestart = document.getElementById('restart');
 const touchControls = document.getElementById('touchControls');
 const btnUlt = document.getElementById('ultBtn');
+const btnAttack = document.getElementById('attackBtn');
 const btnJump = document.getElementById('jumpBtn');
 const btnGacha = document.getElementById('gachaOpen');
 const btnGacha10 = document.getElementById('gacha10');
@@ -441,50 +442,49 @@ function setHUD(remainMs){
   const effectsClass = effects.length ? 'hudEffects' : 'hudEffects isHidden';
 
   hud.innerHTML = `
-    <div class="hudSection hudLeft">
-      <div class="hudBlock">
+    <div class="hudRow hudRowPrimary">
+      <div class="hudItem hudLife">
         <span class="hudLabel">ライフ</span>
         <span class="hudValue hudHearts">${hearts(lives)}</span>
+        <span class="hudGauge">必殺 ${Math.floor(ult)}%</span>
       </div>
-      <div class="hudBlock">
-        <span class="hudLabel">必殺ゲージ</span>
-        <span class="hudValue">${Math.floor(ult)}%</span>
-      </div>
-    </div>
-    <div class="hudSection hudCenter">
-      <div class="hudScore">
-        <span class="hudScoreLabel">スコア</span>
-        <span class="hudScoreValue">${scoreText}</span>
-      </div>
-      <div class="${effectsClass}">${effectsHtml}</div>
-    </div>
-    <div class="hudSection hudRight">
-      <div class="hudBlock">
+      <div class="hudItem hudTime">
         <span class="hudLabel">残り時間</span>
         <span class="hudValue">${sec}秒</span>
       </div>
-      <div class="hudBlock">
+      <div class="hudItem hudScore">
+        <span class="hudLabel">スコア</span>
+        <span class="hudValue hudScoreValue">${scoreText}</span>
+      </div>
+    </div>
+    <div class="hudRow hudRowSecondary">
+      <div class="hudItem hudStage">
         <span class="hudLabel">ステージ</span>
         <span class="hudValue">${st}</span>
         <span class="hudSub">Lv.${level}</span>
       </div>
-      <div class="hudBlock">
+      <div class="hudItem hudCoins">
         <span class="hudLabel">コイン</span>
         <span class="hudValue">🪙${coinText}</span>
       </div>
-      <div class="hudBlock">
+      <div class="hudItem hudBest">
         <span class="hudLabel">ベスト</span>
         <span class="hudValue">${bestText}</span>
       </div>
-    </div>`;
+    </div>
+    <div class="${effectsClass}">${effectsHtml}</div>`;
 
   charInfo.textContent = `CHAR: ${ch.emoji} ${ch.name} [${ch.rar}]  LB:${lb}`;
 
   if (touchControls){
     touchControls.classList.toggle('isVisible', gameOn);
+    touchControls.setAttribute('aria-hidden', gameOn ? 'false' : 'true');
   }
   if (btnJump){
     btnJump.disabled = !gameOn;
+  }
+  if (btnAttack){
+    btnAttack.disabled = !gameOn;
   }
   if (btnUlt){
     const ready = gameOn && ultReady;
@@ -1053,6 +1053,16 @@ function tryUlt(){
 }
 
 // PCキー
+function bindActionButton(button, handler){
+  if (!button) return;
+  const activate = e => {
+    e.preventDefault();
+    handler();
+  };
+  button.addEventListener('pointerdown', activate);
+  button.addEventListener('click', e => e.preventDefault());
+}
+
 window.addEventListener('keydown', e=>{
   if (e.code==='Space' || e.code==='ArrowUp') jump();
   if (e.key==='z'||e.key==='x'||e.key==='Z'||e.key==='X') shoot();
@@ -1074,7 +1084,9 @@ cv.addEventListener('touchstart', e=>{
   }
 },{passive:false});
 cv.addEventListener('touchend', ()=>{ pressedRight=false; clearTimeout(pressTimer); }, {passive:true});
-btnUlt.addEventListener('click', tryUlt);
+bindActionButton(btnJump, jump);
+bindActionButton(btnAttack, shoot);
+bindActionButton(btnUlt, tryUlt);
 
 // ====== キャラ適用 ======
 let currentStats = getEffectiveStats(currentCharKey);

--- a/styles.css
+++ b/styles.css
@@ -6,62 +6,67 @@
   #wrap{max-width:var(--maxw);margin:0 auto;padding:8px;position:relative}
   #hud{
     position:absolute;
-    top:clamp(8px,2.4vh,28px);
+    top:clamp(6px,1.8vh,20px);
     left:50%;
     transform:translateX(-50%);
     width:100%;
     max-width:var(--maxw);
     display:flex;
     flex-direction:column;
-    align-items:stretch;
-    gap:clamp(6px,1vh,12px);
-    padding:0 clamp(12px,4vw,36px);
+    align-items:center;
+    gap:4px;
+    padding:0 clamp(8px,3vw,18px);
     pointer-events:none;
-    font-size:clamp(12px,2.6vw,16px);
+    font-size:clamp(11px,2.2vw,14px);
     color:#0f172a;
+    z-index:5;
   }
   .hudRow{
     width:100%;
     display:flex;
-    align-items:stretch;
-    justify-content:space-between;
-    gap:clamp(10px,3vw,24px);
+    align-items:center;
+    justify-content:center;
     flex-wrap:wrap;
+    gap:clamp(12px,3vw,28px);
+    row-gap:4px;
   }
   .hudItem{
-    flex:1 1 200px;
+    flex:0 1 auto;
     min-width:0;
     display:flex;
-    flex-direction:column;
-    gap:4px;
-    padding:10px clamp(14px,3vw,24px);
-    border-radius:18px;
-    background:rgba(248,250,252,.9);
-    box-shadow:0 10px 22px rgba(15,23,42,.18);
-    backdrop-filter:blur(8px);
+    align-items:center;
+    justify-content:flex-start;
+    flex-wrap:wrap;
+    column-gap:.4em;
+    row-gap:2px;
+    padding:0;
+    border-radius:0;
+    background:transparent;
+    box-shadow:none;
+    backdrop-filter:none;
+    line-height:1.1;
   }
-  .hudRowSecondary .hudItem{background:rgba(248,250,252,.82)}
-  .hudLabel{font-size:clamp(10px,2.2vw,12px);letter-spacing:.08em;text-transform:uppercase;color:#2563eb;font-weight:600}
-  .hudValue{font-weight:600;font-variant-numeric:tabular-nums;font-size:clamp(16px,3.4vw,22px);color:#0f172a}
-  .hudHearts{font-size:clamp(24px,5.4vw,32px);line-height:1}
-  .hudSub,.hudGauge{font-size:clamp(11px,2.4vw,13px);color:#475569;font-weight:600}
-  .hudScoreValue{font-size:clamp(28px,7vw,46px);font-weight:700;letter-spacing:.04em;line-height:1}
-  .hudEffects{display:flex;flex-wrap:wrap;justify-content:center;gap:clamp(6px,2vw,14px);width:100%;min-height:clamp(26px,5vh,38px)}
+  .hudLabel{font-size:.72em;letter-spacing:.08em;text-transform:uppercase;color:#1d4ed8;font-weight:700}
+  .hudValue{font-weight:600;font-variant-numeric:tabular-nums;font-size:1.05em;color:#0f172a;letter-spacing:.01em}
+  .hudHearts{font-size:1.15em;line-height:1}
+  .hudSub,.hudGauge{font-size:.78em;color:#475569;font-weight:600}
+  .hudScoreValue{font-size:1.32em;font-weight:700;letter-spacing:.04em;line-height:1}
+  .hudEffects{display:flex;flex-wrap:wrap;justify-content:center;gap:clamp(4px,1.6vw,12px);width:100%;min-height:0;padding-top:2px}
   .hudEffects.isHidden{display:none}
   .hudEffect{
     display:inline-flex;
     align-items:center;
-    gap:6px;
-    padding:4px 12px;
+    gap:5px;
+    padding:3px 10px;
     border-radius:999px;
-    background:rgba(15,23,42,.78);
+    background:rgba(15,23,42,.72);
     color:#f8fafc;
-    font-size:clamp(11px,2.8vw,14px);
+    font-size:clamp(10px,2.4vw,13px);
     font-weight:600;
-    box-shadow:0 6px 16px rgba(15,23,42,.32);
+    box-shadow:0 6px 14px rgba(15,23,42,.24);
   }
-  .hudEffect .icon{font-size:clamp(18px,4.6vw,22px)}
-  .hudEffect .label{font-size:clamp(11px,2.6vw,13px)}
+  .hudEffect .icon{font-size:clamp(16px,4vw,20px)}
+  .hudEffect .label{font-size:clamp(10px,2.4vw,12px)}
   .hudEffect .time{font-variant-numeric:tabular-nums}
   canvas{width:100%;height:auto;max-width:var(--maxw);background:linear-gradient(#9ed6ee,#fff7e6);border:2px solid #333;border-radius:12px;touch-action:none}
   #btns{
@@ -71,7 +76,7 @@
     margin:18px auto 14px;
     max-width:var(--maxw);
   }
-  #btns .primaryBtns{
+  .primaryBtns{
     display:flex;
     flex-wrap:wrap;
     gap:10px;
@@ -125,16 +130,49 @@
   #objective strong{color:#fbbf24}
   #charInfo{
     position:absolute;
-    top:clamp(92px,18vh,128px);
+    top:clamp(70px,14vh,104px);
     right:clamp(12px,4vw,36px);
-    font-size:clamp(11px,2.6vw,14px);
-    background:rgba(15,23,42,.78);
+    font-size:clamp(11px,2.4vw,13px);
+    background:rgba(15,23,42,.72);
     color:#fff;
-    padding:6px 12px;
-    border-radius:12px;
-    box-shadow:0 8px 20px rgba(15,23,42,.3);
+    padding:6px 10px;
+    border-radius:10px;
+    box-shadow:0 8px 18px rgba(15,23,42,.28);
     pointer-events:none;
 
+  }
+
+  .startScreen{
+    position:absolute;
+    inset:0;
+    display:flex;
+    align-items:center;
+    justify-content:center;
+    pointer-events:none;
+    transition:opacity .24s ease;
+    z-index:4;
+  }
+  .startScreenInner{
+    pointer-events:auto;
+    display:flex;
+    flex-direction:column;
+    align-items:center;
+    gap:12px;
+    padding:16px 22px;
+    border-radius:18px;
+    background:rgba(15,23,42,.82);
+    color:#f8fafc;
+    box-shadow:0 16px 36px rgba(15,23,42,.32);
+  }
+  .startScreenTitle{
+    margin:0;
+    font-size:clamp(18px,3vw,26px);
+    font-weight:700;
+    letter-spacing:.04em;
+  }
+  .startScreen.isHidden{
+    opacity:0;
+    visibility:hidden;
   }
 
   #touchControls{
@@ -187,12 +225,12 @@
     #hud{
       position:static;
       transform:none;
-      padding:0 10px;
-      align-items:stretch;
-      gap:12px;
+      padding:0 12px;
+      align-items:center;
+      gap:6px;
     }
-    .hudRow{flex-direction:column;gap:10px;}
-    .hudItem{flex:1 1 100%;}
+    .hudRow{justify-content:center;}
+    .hudItem{justify-content:center;text-align:center;}
     #touchControls{border-radius:16px 16px 0 0;margin:12px auto 0;}
     #charInfo{
       position:static;

--- a/styles.css
+++ b/styles.css
@@ -6,48 +6,47 @@
   #wrap{max-width:var(--maxw);margin:0 auto;padding:8px;position:relative}
   #hud{
     position:absolute;
-    top:clamp(8px,2.6vh,28px);
-    left:0;
+    top:clamp(8px,2.4vh,28px);
+    left:50%;
+    transform:translateX(-50%);
     width:100%;
+    max-width:var(--maxw);
     display:flex;
-    justify-content:space-between;
-    align-items:flex-start;
-    padding:0 clamp(12px,3vw,36px);
+    flex-direction:column;
+    align-items:stretch;
+    gap:clamp(6px,1vh,12px);
+    padding:0 clamp(12px,4vw,36px);
     pointer-events:none;
     font-size:clamp(12px,2.6vw,16px);
     color:#0f172a;
-    gap:clamp(8px,1.4vw,18px);
   }
-  .hudSection{display:flex;flex-direction:column;gap:clamp(6px,1.2vh,12px);min-width:0}
-  .hudLeft,.hudRight{max-width:34vw}
-  .hudLeft{align-items:flex-start}
-  .hudRight{align-items:flex-end}
-  .hudBlock{
+  .hudRow{
+    width:100%;
+    display:flex;
+    align-items:stretch;
+    justify-content:space-between;
+    gap:clamp(10px,3vw,24px);
+    flex-wrap:wrap;
+  }
+  .hudItem{
+    flex:1 1 200px;
+    min-width:0;
     display:flex;
     flex-direction:column;
-    gap:2px;
-    padding:8px 12px;
-    border-radius:12px;
-    background:rgba(248,250,252,.86);
-    box-shadow:0 6px 18px rgba(15,23,42,.18);
+    gap:4px;
+    padding:10px clamp(14px,3vw,24px);
+    border-radius:18px;
+    background:rgba(248,250,252,.9);
+    box-shadow:0 10px 22px rgba(15,23,42,.18);
     backdrop-filter:blur(8px);
   }
-  .hudRight .hudBlock{align-items:flex-end;text-align:right}
+  .hudRowSecondary .hudItem{background:rgba(248,250,252,.82)}
   .hudLabel{font-size:clamp(10px,2.2vw,12px);letter-spacing:.08em;text-transform:uppercase;color:#2563eb;font-weight:600}
-  .hudValue{font-weight:600;font-variant-numeric:tabular-nums;font-size:clamp(14px,3vw,18px);color:#0f172a}
-  .hudHearts{font-size:clamp(22px,5vw,28px);line-height:1}
-  .hudSub{font-size:clamp(11px,2.4vw,13px);color:#475569;font-weight:600}
-  .hudCenter{align-items:center;justify-content:flex-start;text-align:center;gap:clamp(6px,1vh,12px)}
-  .hudScore{
-    background:rgba(15,23,42,.88);
-    color:#fff;
-    padding:10px clamp(22px,6vw,36px);
-    border-radius:999px;
-    box-shadow:0 8px 24px rgba(15,23,42,.35);
-  }
-  .hudScoreLabel{display:block;font-size:clamp(10px,2.2vw,12px);letter-spacing:.12em;text-transform:uppercase;opacity:.75}
-  .hudScoreValue{display:block;font-size:clamp(28px,8vw,50px);font-weight:700;letter-spacing:.06em;line-height:1}
-  .hudEffects{display:flex;flex-wrap:wrap;justify-content:center;gap:clamp(6px,2vw,14px);min-height:clamp(26px,5vh,38px)}
+  .hudValue{font-weight:600;font-variant-numeric:tabular-nums;font-size:clamp(16px,3.4vw,22px);color:#0f172a}
+  .hudHearts{font-size:clamp(24px,5.4vw,32px);line-height:1}
+  .hudSub,.hudGauge{font-size:clamp(11px,2.4vw,13px);color:#475569;font-weight:600}
+  .hudScoreValue{font-size:clamp(28px,7vw,46px);font-weight:700;letter-spacing:.04em;line-height:1}
+  .hudEffects{display:flex;flex-wrap:wrap;justify-content:center;gap:clamp(6px,2vw,14px);width:100%;min-height:clamp(26px,5vh,38px)}
   .hudEffects.isHidden{display:none}
   .hudEffect{
     display:inline-flex;
@@ -65,7 +64,29 @@
   .hudEffect .label{font-size:clamp(11px,2.6vw,13px)}
   .hudEffect .time{font-variant-numeric:tabular-nums}
   canvas{width:100%;height:auto;max-width:var(--maxw);background:linear-gradient(#9ed6ee,#fff7e6);border:2px solid #333;border-radius:12px;touch-action:none}
-  #btns{display:flex;gap:8px;justify-content:center;margin:10px 0;flex-wrap:wrap}
+  #btns{
+    display:flex;
+    flex-direction:column;
+    gap:16px;
+    margin:18px auto 14px;
+    max-width:var(--maxw);
+  }
+  #btns .primaryBtns{
+    display:flex;
+    flex-wrap:wrap;
+    gap:10px;
+    justify-content:center;
+  }
+  #btns .secondaryBtns{
+    display:flex;
+    gap:10px;
+    overflow-x:auto;
+    padding:12px 10px;
+    border-radius:16px;
+    background:rgba(15,23,42,.08);
+    scroll-snap-type:x mandatory;
+  }
+  #btns .secondaryBtns button{flex:0 0 auto;scroll-snap-align:center}
   button{appearance:none;border:0;border-radius:10px;padding:10px 16px;font-size:16px;background:#22c55e;color:#fff;box-shadow:0 2px 0 rgba(0,0,0,.2);cursor:pointer;transition:transform .16s ease,box-shadow .16s ease}
   button.secondary{background:#3b82f6}
   button.ghost{background:#6b7280}
@@ -117,85 +138,74 @@
   }
 
   #touchControls{
-    position:fixed;
-    inset:0;
+    position:sticky;
+    bottom:0;
+    width:100%;
+    max-width:var(--maxw);
+    margin:18px auto 0;
     display:flex;
-    align-items:flex-end;
-    justify-content:flex-end;
-    padding:0;
-    z-index:15;
+    justify-content:center;
+    gap:clamp(12px,4vw,22px);
+    padding:14px clamp(12px,4vw,24px);
+    background:rgba(15,23,42,.78);
+    border-radius:18px 18px 0 0;
+    box-shadow:0 -12px 28px rgba(15,23,42,.22);
     opacity:0;
-    transition:opacity .22s ease;
+    transform:translateY(16px);
+    transition:opacity .22s ease,transform .22s ease;
     pointer-events:none;
   }
-  #touchControls.isVisible{opacity:1;}
+  #touchControls.isVisible{opacity:1;transform:translateY(0);pointer-events:auto;}
   #touchControls .touchBtn{
-    position:absolute;
+    flex:1 1 0;
+    min-width:0;
     display:flex;
     align-items:center;
     justify-content:center;
-    pointer-events:auto;
     border:0;
-    border-radius:999px;
-    padding:0;
-    width:clamp(78px,18vw,122px);
-    height:clamp(78px,18vw,122px);
-    font-size:clamp(14px,4.2vw,18px);
+    border-radius:12px;
+    padding:14px clamp(16px,5vw,24px);
+    font-size:clamp(16px,4.6vw,20px);
     font-weight:700;
-    letter-spacing:.04em;
-    background:rgba(15,23,42,.85);
-    color:#fff;
-    box-shadow:0 12px 28px rgba(15,23,42,.35);
+    letter-spacing:.08em;
     text-transform:none;
-    transition:transform .18s ease,opacity .18s ease,box-shadow .18s ease;
+    background:rgba(15,23,42,.88);
+    color:#fff;
+    box-shadow:0 10px 24px rgba(15,23,42,.28);
+    cursor:pointer;
+    transition:transform .16s ease,box-shadow .16s ease,opacity .16s ease;
   }
-  #touchControls #jumpBtn{
-    right:clamp(14px,5vw,32px);
-    bottom:clamp(6vh,10vh,96px);
-    background:rgba(34,197,94,.9);
-  }
-  #touchControls .touchUlt{
-    right:clamp(12px,4.6vw,28px);
-    bottom:clamp(28vh,34vh,240px);
-    background:linear-gradient(160deg,#f97316,#ec4899);
-  }
-  #touchControls .touchBtn:disabled{opacity:.45;transform:scale(.96);box-shadow:none}
-  #touchControls .touchUlt.isReady{box-shadow:0 16px 30px rgba(236,72,153,.45);transform:scale(1.04)}
+  #touchControls .touchBtn:active{transform:translateY(2px);}
+  #touchControls .touchJump{background:#22c55e;}
+  #touchControls .touchAttack{background:#3b82f6;}
+  #touchControls .touchUlt{background:linear-gradient(160deg,#f97316,#ec4899);}
+  #touchControls .touchBtn:disabled{opacity:.5;box-shadow:none;cursor:not-allowed;}
+  #touchControls .touchUlt.isReady{box-shadow:0 16px 30px rgba(236,72,153,.45);}
 
   @media (max-width: 768px){
     #wrap{display:flex;flex-direction:column;align-items:stretch;gap:12px;padding:12px 12px 20px;position:relative;}
     #hud{
       position:static;
-      flex-direction:column;
+      transform:none;
+      padding:0 10px;
       align-items:stretch;
-      justify-content:flex-start;
       gap:12px;
-      padding:0 8px;
     }
-    .hudSection{
-      display:flex;
-      flex-wrap:wrap;
-      flex-direction:row;
-      gap:8px;
-    }
-    .hudLeft,.hudRight{max-width:none;align-items:flex-start}
-    .hudRight .hudBlock{align-items:flex-start;text-align:left}
-    .hudBlock{flex:1 1 calc(50% - 8px);min-width:140px}
-    .hudCenter{order:-1;align-items:center;text-align:center}
-    .hudCenter .hudScore{width:100%;max-width:320px;margin:0 auto}
-    .hudEffects{justify-content:center}
+    .hudRow{flex-direction:column;gap:10px;}
+    .hudItem{flex:1 1 100%;}
+    #touchControls{border-radius:16px 16px 0 0;margin:12px auto 0;}
     #charInfo{
       position:static;
       align-self:flex-end;
-      margin:0 8px;
+      margin:0 10px;
     }
   }
 
   @media (max-width: 480px){
-    .hudSection{flex-direction:column;gap:6px}
-    .hudBlock{flex:1 1 100%;min-width:auto}
-    .hudCenter .hudScore{max-width:none}
     #wrap{gap:10px;padding:12px 10px 20px;}
+    .hudItem{padding:10px 14px;}
+    #btns .secondaryBtns{padding:12px 8px;}
+    #touchControls{padding:12px 14px;gap:10px;}
   }
 
   /* ガチャ & コレクション オーバーレイ */


### PR DESCRIPTION
## Summary
- restructure the HUD so life, time, and score share the first row while stage, coins, and best score appear beneath
- introduce a bottom action bar with jump, attack, and ultimate buttons and move secondary menus into a scrollable group
- update styles and scripts to support the new layout, disable buttons when inactive, and wire up the attack control

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d8cc9a001483209f2ebda16a950318