### PR TITLE
Adjust mobile touch button sizing

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -244,6 +244,11 @@
     .hudItem{padding:10px 14px;}
     #btns .secondaryBtns{padding:12px 8px;}
     #touchControls{padding:12px 14px;gap:10px;}
+    #touchControls .touchBtn{
+      padding:10px clamp(14px,5vw,20px);
+      font-size:clamp(14px,4.8vw,18px);
+      letter-spacing:.06em;
+    }
   }
 
   /* ガチャ & コレクション オーバーレイ */

--- a/styles.css
+++ b/styles.css
@@ -202,8 +202,8 @@
     justify-content:center;
     border:0;
     border-radius:12px;
-    padding:14px clamp(16px,5vw,24px);
-    font-size:clamp(16px,4.6vw,20px);
+    padding:14px clamp(16px,5vw,20px);
+    font-size:clamp(14px,4.6vw,10px);
     font-weight:700;
     letter-spacing:.08em;
     text-transform:none;


### PR DESCRIPTION
## Summary
- shrink the touch control buttons for small screens so they no longer overlap the play field
- tune typography on the buttons to maintain readability after reducing the padding

## Testing
- none

------
https://chatgpt.com/codex/tasks/task_e_68d9414632448320b8c97fef61e7532d