### PR TITLE
Hide objective after first visit

### DIFF
--- a/index.html
+++ b/index.html
@@ -148,6 +148,7 @@
       <div class="cardBody">
         <p id="howLead" class="howLead"></p>
         <ul id="howList" class="howList"></ul>
+        <section id="howObjective" class="howObjective" aria-live="polite"></section>
       </div>
       <div class="howFooter">
         <span id="howFooterNote" class="howFooterNote"></span>

--- a/index_remote.html
+++ b/index_remote.html
@@ -155,6 +155,7 @@ if ('serviceWorker' in navigator) {
       <div class="cardBody">
         <p id="howLead" class="howLead"></p>
         <ul id="howList" class="howList"></ul>
+        <section id="howObjective" class="howObjective" aria-live="polite"></section>
       </div>
       <div class="howFooter">
         <span id="howFooterNote" class="howFooterNote"></span>

--- a/js/howto.js
+++ b/js/howto.js
@@ -8,7 +8,9 @@
     start: document.getElementById('howStart'),
     lead: document.getElementById('howLead'),
     list: document.getElementById('howList'),
-    footer: document.getElementById('howFooterNote')
+    footer: document.getElementById('howFooterNote'),
+    objective: document.getElementById('objective'),
+    objectiveSlot: document.getElementById('howObjective')
   };
 
   const DEFAULT_COPY = {
@@ -84,6 +86,30 @@
     overlay.style.display = 'flex';
   }
 
+  function ensureObjectiveCopy(){
+    const { objective, objectiveSlot } = elements;
+    if (!objective || !objectiveSlot || objectiveSlot.dataset.bound === '1') return;
+
+    const clone = objective.cloneNode(true);
+    clone.removeAttribute('id');
+    const heading = clone.querySelector('h2');
+    if (heading){
+      const replacement = document.createElement('h3');
+      replacement.innerHTML = heading.innerHTML;
+      heading.replaceWith(replacement);
+    }
+    clone.classList.add('howObjectiveContent');
+    objectiveSlot.appendChild(clone);
+    objectiveSlot.dataset.bound = '1';
+  }
+
+  function collapseObjective(){
+    const { objective } = elements;
+    if (!objective) return;
+    objective.setAttribute('hidden', 'hidden');
+    objective.setAttribute('aria-hidden', 'true');
+  }
+
   function close(){
     if (elements.overlay){
       elements.overlay.style.display = 'none';
@@ -103,6 +129,7 @@
 
     render();
     loadCopy();
+    ensureObjectiveCopy();
 
     if (elements.button){
       elements.button.addEventListener('click', () => open(false));
@@ -115,17 +142,22 @@
     }
 
     const INTRO_KEY = 'psrun_intro_seen_v2';
-    let shouldOpen = true;
+    let isFirstVisit = true;
     try {
       if (localStorage.getItem(INTRO_KEY)){
-        shouldOpen = false;
+        isFirstVisit = false;
       } else {
         localStorage.setItem(INTRO_KEY, '1');
       }
     } catch {
-      shouldOpen = true;
+      isFirstVisit = true;
     }
-    if (shouldOpen){
+
+    if (!isFirstVisit){
+      collapseObjective();
+    }
+
+    if (isFirstVisit){
       open(true);
     }
   }

--- a/styles.css
+++ b/styles.css
@@ -128,6 +128,22 @@
   #objective ul{margin:0;padding-left:22px;display:grid;gap:4px;font-size:clamp(12px,3.2vw,16px)}
   #objective li::marker{color:#facc15}
   #objective strong{color:#fbbf24}
+  .howObjective{
+    margin-top:16px;
+    background:rgba(15,23,42,.45);
+    color:#f9fafb;
+    border-radius:14px;
+    padding:12px 14px;
+    text-align:left;
+    box-shadow:inset 0 0 0 1px rgba(148,163,184,.18);
+  }
+  .howObjective:empty{display:none}
+  .howObjective section{margin:0}
+  .howObjective h3{margin:0 0 6px;font-size:clamp(16px,3vw,20px)}
+  .howObjective p{margin:0 0 8px;line-height:1.6}
+  .howObjective ul{margin:0;padding-left:22px;display:grid;gap:4px;font-size:clamp(12px,3vw,15px)}
+  .howObjective li::marker{color:#facc15}
+  .howObjective strong{color:#fbbf24}
   #charInfo{
     position:absolute;
     top:clamp(70px,14vh,104px);


### PR DESCRIPTION
## Summary
- add a dedicated container in the how-to overlay to show the game objective text
- clone the existing objective copy into the overlay and hide the top-level section after the first visit
- mirror the markup update in the remote index and style the overlay objective block

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9457f5cac8320bede45b7d01d1b7a