### PR TITLE
Scale scene layout to fit small screens without scrolling

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,6 +22,7 @@
 
 <body>
   <div class="scene-wrap" id="sceneWrap">
+    <div class="scene-root">
   <!-- === Splash / Fade / Titles / Speedlines === -->
   <div id="splash" class="splash" role="status" aria-live="polite">
     <div class="splash-inner">
@@ -289,8 +290,6 @@
     </div>
   </div>
 
-
-  </div><!-- /scene-wrap -->
   <div class="vignette" id="vignette"></div>
   <div class="combo" id="combo"></div>
   <div class="fever" id="fever"></div>
@@ -306,8 +305,43 @@
   </div>
 
 
-<script type="module" src="main.js"></script>
-<script>
+    </div>
+  </div><!-- /scene-wrap -->
+  <script type="module" src="main.js"></script>
+  <script>
+(function(){
+  const BASE_W = 390;
+  const BASE_H = 844;
+
+  const rootStyle = document.documentElement.style;
+  rootStyle.setProperty('--scene-base-w', BASE_W + 'px');
+  rootStyle.setProperty('--scene-base-h', BASE_H + 'px');
+
+  function getVisualHeight(){
+    if (window.visualViewport && typeof window.visualViewport.height === 'number') {
+      return Math.max(1, window.visualViewport.height);
+    }
+    return Math.max(1, window.innerHeight);
+  }
+
+  function fitScene(){
+    const vw = Math.max(1, window.innerWidth);
+    const vh = getVisualHeight();
+    const scale = Math.min(1, vw / BASE_W, vh / BASE_H);
+    rootStyle.setProperty('--scene-scale', scale.toFixed(4));
+  }
+
+  window.addEventListener('resize', fitScene, {passive:true});
+  window.addEventListener('orientationchange', fitScene, {passive:true});
+  if (window.visualViewport) {
+    window.visualViewport.addEventListener('resize', fitScene, {passive:true});
+    window.visualViewport.addEventListener('scroll', fitScene, {passive:true});
+  }
+  document.addEventListener('DOMContentLoaded', fitScene);
+  fitScene();
+})();
+  </script>
+  <script>
 (function(){
   const params = new URLSearchParams(location.search);
   const dev = params.has('dev'); // ?dev を付けたら開発モーチE

--- a/styles.css
+++ b/styles.css
@@ -513,19 +513,34 @@
 /* 画面ズーム用のラッパ。body直下に .scene-wrap を1つ被せる想定 */
 .scene-wrap{
   position: fixed;
-  inset: 0;
+  inset: env(safe-area-inset-top, 0px) env(safe-area-inset-right, 0px)
+         env(safe-area-inset-bottom, 0px) env(safe-area-inset-left, 0px);
+  display: grid;
+  place-items: center;
+  overflow: hidden;
+  touch-action: manipulation;
+  -webkit-user-select: none;
+  user-select: none;
   z-index: 1;              /* ← ゲーム層は背面 */
-  transform-origin: center;
-  will-change: transform;
   pointer-events: auto;    /* ← 通常は入力を受ける */
 }
-.scene-wrap.zoomed{
+
+/* 縮小対象 */
+.scene-root{
+  width: var(--scene-base-w, 390px);
+  height: var(--scene-base-h, 844px);
+  transform-origin: top center;
+  transform: scale(var(--scene-scale, 1));
+  will-change: transform;
   transition: transform .12s ease;
-  transform: scale(1.04);
+}
+
+.scene-wrap.zoomed .scene-root{
+  transform: scale(calc(var(--scene-scale, 1) * 1.04));
 }
 
 /* モーダル表示中はゲーム層のヒットテストを無効化 */
-body.modal-open .scene-wrap{ pointer-events: none; }
+body.modal-open .scene-root > :not(.overlay):not(.modal){ pointer-events: none; }
 
 /* モーダル/オーバーレイは常に最前面で操作可 */
 .modal,


### PR DESCRIPTION
## Summary
- wrap the game interface in a new .scene-root container beneath .scene-wrap
- add responsive scaling styles and viewport-safe spacing so the scene shrinks instead of scrolling
- compute --scene-scale from visual viewport measurements to keep iPhone mini UI buttons visible

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da99b444248320838b31a30975b8f8