### PR TITLE
Ensure update button stays outside scene container

### DIFF
--- a/js/app-update.js
+++ b/js/app-update.js
@@ -5,6 +5,15 @@ const VERSION_JSON_URL = '/parfait-sardine-run/version.json';
 function getBtn(){ return document.getElementById('updateBtn'); }
 function getVerEl(){ return document.getElementById('appVersion'); }
 
+export function ensureUpdateBtnOutside(){
+  const btn = getBtn();
+  if (!btn) return;
+  const wrap = document.querySelector('#sceneWrap, .scene-wrap');
+  if (wrap && wrap.contains(btn)){
+    document.body.appendChild(btn);
+  }
+}
+
 function setBadge(on){
   const btn = getBtn();
   if (!btn) return;
@@ -112,6 +121,7 @@ function isNewer(a, b) {
 }
 
 export function initUpdateUI(){
+  ensureUpdateBtnOutside();
   restoreBadge();
   setVersionIndicator({ current: CURRENT_VERSION });
 

--- a/main.js
+++ b/main.js
@@ -15,7 +15,7 @@ import { G, BASE_JUMP, GROUND, GAME_TIME, INVINCIBILITY_DURATION, SHOOT_COOLDOWN
 import { ITEM_CATALOG } from './js/game-data/items.js';
 import { characters, rarOrder, rarClass, SPECIAL_LABELS, ULT_DETAILS } from './js/game-data/characters.js';
 import { stages, stageForLevel, stageBosses } from './js/game-data/stages.js';
-import { registerSW, checkLatestAndBadge, initUpdateUI } from './js/app-update.js';
+import { registerSW, checkLatestAndBadge, initUpdateUI, ensureUpdateBtnOutside } from './js/app-update.js';
 
 // 先頭付近に置く（PSRUN_STARTより前）
 function now(){ return performance.now(); }
@@ -162,6 +162,7 @@ const playerAnimation = {
 })();
 
 window.addEventListener('DOMContentLoaded', async () => {
+  ensureUpdateBtnOutside();
   await registerSW();
   initUpdateUI();
   await checkLatestAndBadge();


### PR DESCRIPTION
## Summary
- add a helper that relocates the update button outside of the scene wrapper when needed
- call the helper during update UI initialization and DOM ready setup to keep the button usable

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dbf9d6f0e48320a0b040494b3fe360