### PR TITLE
Auto-submit leaderboard high scores and add name settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@
 このガイドを起点にコードを読み解き、目的のセクションから掘り下げていってください。必要に応じてメモや図解を作成しながら理解を進めるとスムーズです。
 
 ## 8. WordPress REST API リーダーボード連携
-- ゲーム終了時にスコアが 0 より大きい場合は名前入力ダイアログが表示され、外部の WordPress REST API (`/wp-json/psrun/v2/leaderboard`) へスコアを送信します。送信が失敗した場合はアラートとランキングオーバーレイ内のメッセージで通知します。【F:index.html†L356-L408】【F:index.html†L1045-L1048】
+- ゲーム終了時にスコアが自己ベストを更新した場合のみ、保存済みのプレイヤー名で外部の WordPress REST API (`/wp-json/psrun/v2/leaderboard`) へスコアを自動送信します。送信が失敗した場合はアラートとランキングオーバーレイ内のメッセージで通知します。【F:index.html†L360-L417】【F:js/leaderboard.js†L345-L537】
+- プレイヤー名は初回起動時に「ゲスト」を `localStorage` に保存し、ランキング画面または設定画面の「名前変更」ボタンから更新できます。変更した名前は次回以降のランキング送信やコメント投稿に利用されます。【F:index.html†L130-L146】【F:index.html†L360-L417】【F:js/leaderboard.js†L16-L117】【F:js/settings.js†L1-L88】【F:js/comments.js†L372-L506】
 - 「ランキング」ボタンで開くオーバーレイでは最大 20 件の結果を表示し、API から返却された名前・スコア・レベル・コイン・キャラ・登録時刻を並べます。結果が空のときは “No results yet” と表示されます。【F:index.html†L195-L208】【F:index.html†L296-L348】
 - API ベース URL は既定で `https://howasaba-code.com/wp-json/psrun/v2/leaderboard` を指します。開発や検証で別環境を使いたい場合は、`window.PSRUN_API_BASE` でベースパスを上書きできます。例：`<script>window.PSRUN_API_BASE='https://example.com/wp-json/psrun/v2';</script>` を `index.html` に追加すると、そのドメインの `/leaderboard` エンドポイントに対して通信します。【F:index.html†L262-L287】
 

--- a/index.html
+++ b/index.html
@@ -112,6 +112,7 @@
         <button id="gacha10" class="warn" disabled>10連(100)</button>
         <button id="collection" class="ghost">コレクション</button>
         <button id="codexBtn" class="ghost">図鑑</button>
+        <button id="settingsBtn" class="ghost">設定</button>
         <button id="leaderboardBtn" class="ghost">ランキング</button>
         <button id="commentBtn" class="ghost">コメント</button>
         <span id="versionLabel" class="muted" aria-live="polite"></span>
@@ -268,7 +269,11 @@
         </div>
         <div class="cardBody">
           <div class="leaderboardControls">
-            <button id="leaderboardJump" class="ghost">自分の順位へ</button>
+            <span id="leaderboardPlayerName" class="leaderboardPlayerName">現在の名前：-</span>
+            <div class="leaderboardControlButtons">
+              <button id="leaderboardRename" class="ghost">名前変更</button>
+              <button id="leaderboardJump" class="ghost">自分の順位へ</button>
+            </div>
           </div>
           <p id="leaderboardStatus" class="howLead">読み込み中…</p>
           <ol id="leaderboardList" class="leaderboardList"></ol>
@@ -306,6 +311,24 @@
           </form>
           <p id="commentStatus" class="howLead" style="display:none"></p>
           <ul id="commentList" class="commentList"></ul>
+        </div>
+      </div>
+    </div>
+
+    <!-- 設定 -->
+    <div id="settingsOverlay" class="overlay" hidden>
+      <div class="cardWrap">
+        <div class="cardHeader">
+          <h2>設定</h2>
+          <button id="settingsClose" class="ghost">閉じる</button>
+        </div>
+        <div class="cardBody settingsBody">
+          <section class="settingsSection">
+            <h3>プレイヤー名</h3>
+            <p id="settingsPlayerName" class="settingsPlayerName">現在の名前：-</p>
+            <button id="settingsRename" class="secondary">名前を変更</button>
+            <p class="settingsHelp">ランキングに送信される名前です。1〜40文字で設定できます。</p>
+          </section>
         </div>
       </div>
     </div>

--- a/index_remote.html
+++ b/index_remote.html
@@ -116,6 +116,7 @@ if ('serviceWorker' in navigator) {
         <button id="gacha10" class="warn" disabled>10連(100)</button>
         <button id="collection" class="ghost">コレクション</button>
         <button id="codexBtn" class="ghost">図鑑</button>
+        <button id="settingsBtn" class="ghost">設定</button>
         <button id="leaderboardBtn" class="ghost">ランキング</button>
         <button id="commentBtn" class="ghost">コメント</button>
       </div>
@@ -248,7 +249,11 @@ if ('serviceWorker' in navigator) {
       </div>
       <div class="cardBody">
         <div class="leaderboardControls">
-          <button id="leaderboardJump" class="ghost">自分の順位へ</button>
+          <span id="leaderboardPlayerName" class="leaderboardPlayerName">現在の名前：-</span>
+          <div class="leaderboardControlButtons">
+            <button id="leaderboardRename" class="ghost">名前変更</button>
+            <button id="leaderboardJump" class="ghost">自分の順位へ</button>
+          </div>
         </div>
         <p id="leaderboardStatus" class="howLead">読み込み中…</p>
         <ol id="leaderboardList" class="leaderboardList"></ol>
@@ -296,10 +301,29 @@ if ('serviceWorker' in navigator) {
     </div>
   </div>
 
+  <!-- 設定 -->
+  <div id="settingsOverlay" class="overlay">
+    <div class="cardWrap">
+      <div class="cardHeader">
+        <h2>設定</h2>
+        <button id="settingsClose" class="ghost">閉じる</button>
+      </div>
+      <div class="cardBody settingsBody">
+        <section class="settingsSection">
+          <h3>プレイヤー名</h3>
+          <p id="settingsPlayerName" class="settingsPlayerName">現在の名前：-</p>
+          <button id="settingsRename" class="secondary">名前を変更</button>
+          <p class="settingsHelp">ランキングに送信される名前です。1〜40文字で設定できます。</p>
+        </section>
+      </div>
+    </div>
+  </div>
+
 
 <script src="js/utils.js"></script>
 <script src="js/howto.js"></script>
 <script src="js/leaderboard.js"></script>
+<script src="js/settings.js"></script>
 <script src="js/comments.js"></script>
 <script src="main.js"></script>
 <script>

--- a/js/comments.js
+++ b/js/comments.js
@@ -376,7 +376,7 @@
   async function submitComment(){
     if (!elements.messageInput || !elements.status || !elements.submit) return;
     const rawName = elements.nameInput?.value ?? '';
-    const sanitizedName = Utils.sanitizeName(rawName) || Leaderboard.DEFAULT_PLAYER_NAME || 'プレイヤー';
+    const sanitizedName = Utils.sanitizeName(rawName) || Leaderboard.DEFAULT_PLAYER_NAME || 'ゲスト';
     const nameLength = Utils.graphemeLength(sanitizedName);
     if (nameLength < 1 || nameLength > 40){
       elements.status.textContent = '名前は1〜40文字で入力してください。';
@@ -491,7 +491,7 @@
       elements.status.textContent = '';
     }
     if (elements.nameInput){
-      const stored = Utils.sanitizeName(Leaderboard.loadPlayerName?.() || Leaderboard.DEFAULT_PLAYER_NAME || 'プレイヤー');
+      const stored = Utils.sanitizeName(Leaderboard.loadPlayerName?.() || Leaderboard.DEFAULT_PLAYER_NAME || 'ゲスト');
       if (stored && !elements.nameInput.value){
         elements.nameInput.value = stored;
       }

--- a/js/settings.js
+++ b/js/settings.js
@@ -1,0 +1,108 @@
+(function(){
+  const elements = {
+    button: document.getElementById('settingsBtn'),
+    overlay: document.getElementById('settingsOverlay'),
+    close: document.getElementById('settingsClose'),
+    name: document.getElementById('settingsPlayerName'),
+    rename: document.getElementById('settingsRename')
+  };
+
+  function leaderboardModule(){
+    return window.PSR?.Leaderboard || null;
+  }
+
+  function resolvePlayerName(){
+    const lb = leaderboardModule();
+    if (!lb) return 'ゲスト';
+    if (typeof lb.ensurePlayerName === 'function'){
+      try { return lb.ensurePlayerName(); }
+      catch { }
+    }
+    if (typeof lb.loadPlayerName === 'function'){
+      const loaded = lb.loadPlayerName();
+      if (loaded) return loaded;
+    }
+    if (typeof lb.DEFAULT_PLAYER_NAME === 'string' && lb.DEFAULT_PLAYER_NAME){
+      return lb.DEFAULT_PLAYER_NAME;
+    }
+    return 'ゲスト';
+  }
+
+  function updateNameDisplay(name){
+    const target = elements.name;
+    const finalName = typeof name === 'string' && name ? name : resolvePlayerName();
+    if (target){
+      target.textContent = `現在の名前：${finalName}`;
+    }
+  }
+
+  function openOverlay(){
+    if (!elements.overlay) return;
+    const UI = window.PSR?.UI;
+    if (UI?.openOverlay){
+      UI.openOverlay(elements.overlay);
+    } else {
+      elements.overlay.hidden = false;
+      elements.overlay.classList.add('show');
+      document.body?.classList?.add('modal-open');
+    }
+    updateNameDisplay();
+  }
+
+  function closeOverlay(){
+    if (!elements.overlay) return;
+    const UI = window.PSR?.UI;
+    if (UI?.closeOverlay){
+      UI.closeOverlay(elements.overlay);
+    } else {
+      elements.overlay.hidden = true;
+      elements.overlay.classList.remove('show');
+      if (!document.querySelector('.overlay:not([hidden])')){
+        document.body?.classList?.remove('modal-open');
+      }
+    }
+  }
+
+  async function handleRename(){
+    const lb = leaderboardModule();
+    if (!lb) return;
+    if (typeof lb.requestNameChange === 'function'){
+      const result = await lb.requestNameChange();
+      if (result?.name){
+        updateNameDisplay(result.name);
+      } else {
+        updateNameDisplay();
+      }
+      return;
+    }
+    const current = resolvePlayerName();
+    const input = prompt('新しい名前を入力してください。（1〜40文字）', current);
+    if (input === null) return;
+    const sanitized = (window.PSR?.Utils?.sanitizeName?.(input)) || '';
+    if (!sanitized){
+      alert('名前は1〜40文字で入力してください。');
+      return;
+    }
+    const saved = typeof lb.savePlayerName === 'function'
+      ? lb.savePlayerName(sanitized)
+      : sanitized;
+    updateNameDisplay(saved);
+  }
+
+  if (elements.button){
+    elements.button.addEventListener('click', openOverlay);
+  }
+  if (elements.close){
+    elements.close.addEventListener('click', closeOverlay);
+  }
+  if (elements.rename){
+    elements.rename.addEventListener('click', handleRename);
+  }
+
+  window.addEventListener('psr:playerNameChanged', event => {
+    const detailName = event?.detail?.name;
+    updateNameDisplay(detailName);
+  });
+
+  updateNameDisplay();
+})();

--- a/main.js
+++ b/main.js
@@ -7,6 +7,7 @@
 import './js/utils.js';
 import './js/howto.js';
 import './js/leaderboard.js';
+import './js/settings.js';
 import './js/comments.js';
 
 import { showStageTitle, cameraShake, floatText, speedSE } from './js/presentation.js';
@@ -1767,7 +1768,8 @@ function endGame(){
     c.fillText(line, cv.width/2, cv.height/2 + 46 + idx*24);
   });
   const finalResult = { score, level, coins, char: currentCharKey };
-  updateBestScore(finalResult.score);
+  const didUpdateBest = updateBestScore(finalResult.score);
+  finalResult.didUpdateBest = didUpdateBest;
   setHUD(0);
   showResultOverlay(finalResult);
   setStartScreenVisible(true);
@@ -1828,7 +1830,9 @@ function updateBestScore(latestScore){
     bestScore = normalized;
     saveBestScore();
     refreshHUD();
+    return true;
   }
+  return false;
 }
 
 // ====== 初期HUD ======

--- a/styles.css
+++ b/styles.css
@@ -119,7 +119,9 @@
   .lbScore{min-width:120px;text-align:right;font-variant-numeric:tabular-nums}
   .lbDate{min-width:132px;text-align:right;font-size:12px;opacity:.8;font-variant-numeric:tabular-nums}
   .leaderboardItem.selfEntry{box-shadow:0 0 0 2px rgba(250,204,21,.55)}
-  .leaderboardControls{display:flex;justify-content:flex-end;gap:8px;margin-bottom:4px}
+  .leaderboardControls{display:flex;flex-wrap:wrap;align-items:center;justify-content:space-between;gap:8px;margin-bottom:8px}
+  .leaderboardControlButtons{display:flex;gap:8px;flex-wrap:wrap;justify-content:flex-end}
+  .leaderboardPlayerName{font-size:14px;color:rgba(255,255,255,.78)}
   #leaderboardJump{display:none}
   .muted{opacity:.75}
   .controls{max-width:var(--maxw);margin:0 auto;line-height:1.6;text-align:left}
@@ -403,6 +405,13 @@
   .resultList .value small{font-size:12px;color:#facc15}
   .resultList .note{font-size:12px;opacity:.75}
   .resultList li.resultEmpty{justify-content:center;opacity:.6;font-style:italic}
+
+  /* 設定 */
+  .settingsBody{display:flex;flex-direction:column;gap:18px}
+  .settingsSection{display:flex;flex-direction:column;gap:12px;background:rgba(15,23,42,.45);padding:16px;border-radius:12px}
+  .settingsSection h3{margin:0;font-size:16px}
+  .settingsPlayerName{margin:0;font-weight:600;font-size:15px;word-break:break-word}
+  .settingsHelp{margin:0;font-size:13px;line-height:1.6;opacity:.78}
 
   /* コメント */
   .commentBody{display:flex;flex-direction:column;gap:16px}


### PR DESCRIPTION
## Summary
- auto-submit leaderboard scores only when a new personal best is achieved and persist the player name in localStorage with a default of "ゲスト"
- add rename actions to the ranking and new settings overlays, updating the UI and CSS to surface the stored player name
- refresh the documentation to describe the streamlined leaderboard flow and name management

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dbfee58e7883208d2d2759621b9cf7