### PR TITLE
Update service worker cache version for new release

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -1,4 +1,4 @@
-const CACHE_VERSION = "psr-v1.1.1";
+const CACHE_VERSION = "psr-v2025.09.30-02";
 const STATIC_CACHE = `static-${CACHE_VERSION}`;
 const APP_SHELL = [
   "/parfait-sardine-run/",


### PR DESCRIPTION
## Summary
- update the service worker cache version constant to the latest release identifier so a new namespace is used
- ensure static cache and app shell reuse the new identifier so stale caches are purged on activation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd5876c1f48320aaece2a823c281c6