### PR TITLE
Adjust scene scaling translation for narrow view

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -603,19 +603,19 @@
 
   transform-origin: top left;
   /* 縮小が必要な時だけ JS で --scene-scale を < 1 にする。広い時は 1 のまま */
-  transform: translateX(calc((1 - var(--scene-scale, 1)) * -50%))
+  transform: translateX(calc((1 - var(--scene-scale, 1)) * 50%))
     scale(var(--scene-scale, 1));
   will-change: transform;
   transition: transform .12s ease;
 }
 
 body.modal-open .scene-root{
-  transform: translateX(calc((1 - var(--scene-scale, 1)) * -50%))
+  transform: translateX(calc((1 - var(--scene-scale, 1)) * 50%))
     scale(var(--scene-scale, 1));
 }
 
 .scene-wrap.zoomed .scene-root{
-  transform: translateX(calc((1 - (var(--scene-scale, 1) * 1.04)) * -50%))
+  transform: translateX(calc((1 - (var(--scene-scale, 1) * 1.04)) * 50%))
     scale(calc(var(--scene-scale, 1) * 1.04));
 }
 

--- a/styles.css
+++ b/styles.css
@@ -601,19 +601,22 @@
   );
   height: auto;
 
-  transform-origin: top center;
+  transform-origin: top left;
   /* 縮小が必要な時だけ JS で --scene-scale を < 1 にする。広い時は 1 のまま */
-  transform: scale(var(--scene-scale, 1));
+  transform: translateX(calc((1 - var(--scene-scale, 1)) * -50%))
+    scale(var(--scene-scale, 1));
   will-change: transform;
   transition: transform .12s ease;
 }
 
 body.modal-open .scene-root{
-  transform: none;
+  transform: translateX(calc((1 - var(--scene-scale, 1)) * -50%))
+    scale(var(--scene-scale, 1));
 }
 
 .scene-wrap.zoomed .scene-root{
-  transform: scale(calc(var(--scene-scale, 1) * 1.04));
+  transform: translateX(calc((1 - (var(--scene-scale, 1) * 1.04)) * -50%))
+    scale(calc(var(--scene-scale, 1) * 1.04));
 }
 
 /* モーダル表示中はゲーム層のヒットテストを無効化 */


### PR DESCRIPTION
## Summary
- translate the scene root before scaling so the shrunken canvas stays centered within the fixed layout width
- align modal-open and zoomed scene overrides with the translate+scale transform to keep overlays positioned

## Testing
- node server.js (manual viewport verification)


------
https://chatgpt.com/codex/tasks/task_e_68dd5af4d62c8320a7ddf65a91990d98