### PR TITLE
Refine comment sanitizer to drop executable tags

### DIFF
--- a/js/utils.js
+++ b/js/utils.js
@@ -20,16 +20,64 @@
     return clampGraphemes(cleaned, 40);
   }
 
+  function decodeEntities(value){
+    if (!value) return '';
+    const str = String(value);
+    if (typeof document !== 'undefined'){
+      const textarea = decodeEntities.__el || (decodeEntities.__el = document.createElement('textarea'));
+      textarea.innerHTML = str;
+      return textarea.value;
+    }
+    return str
+      .replace(/&lt;/gi, '<')
+      .replace(/&gt;/gi, '>')
+      .replace(/&amp;/gi, '&')
+      .replace(/&quot;/gi, '"')
+      .replace(/&#39;/gi, "'")
+      .replace(/&#x([0-9a-f]+);/gi, (_, hex) => {
+        const code = parseInt(hex, 16);
+        return Number.isFinite(code) ? String.fromCodePoint(code) : '';
+      })
+      .replace(/&#(\d+);/g, (_, num) => {
+        const code = parseInt(num, 10);
+        return Number.isFinite(code) ? String.fromCodePoint(code) : '';
+      });
+  }
+
   function sanitizeCommentMessage(raw, limit = 1000){
     if (!raw) return '';
-    let normalized = String(raw)
+
+    const executableTags = '(?:script|style|template|iframe|object|embed|noscript|svg|math|canvas|applet)';
+    const pairedExecutableRegex = new RegExp(`<\\s*(${executableTags})\\b[^>]*>[\\s\\S]*?<\\s*\\/\\s*\\1\\s*>`, 'gi');
+    const selfClosingExecutableRegex = new RegExp(`<\\s*(${executableTags})\\b[^>]*\\/\\s*>`, 'gi');
+    const trailingExecutableRegex = new RegExp(`<\\s*(${executableTags})\\b[^>]*>[\\s\\S]*$`, 'gi');
+
+    let normalized = decodeEntities(String(raw))
       .replace(/[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F]/g, '')
-      .replace(/<[^>]*>/g, '')
+      .replace(/<!--([\s\S]*?)-->/g, '')
+      .replace(/<\?([\s\S]*?)\?>/g, '')
+      .replace(/<!\[CDATA\[([\s\S]*?)\]\]>/g, '')
       .replace(/\r\n?/g, '\n')
       .replace(/\u00A0/g, ' ');
-    normalized = normalized.replace(/[<>]/g, '');
-    normalized = normalized.trim();
-    return clampGraphemes(normalized, limit).trim();
+
+    let previous;
+    do {
+      previous = normalized;
+      normalized = normalized
+        .replace(pairedExecutableRegex, '')
+        .replace(selfClosingExecutableRegex, '')
+        .replace(trailingExecutableRegex, '');
+    } while (previous !== normalized);
+
+    normalized = normalized
+      .replace(new RegExp(`<\\s*\\/\\s*${executableTags}\\s*>`, 'gi'), '')
+      .replace(/<[^>]*>/g, '')
+      .replace(/[<>]/g, '')
+      .replace(/[ \t\f\v]+/g, ' ')
+      .replace(/\s*\n\s*/g, '\n')
+      .replace(/\n{3,}/g, '\n\n');
+
+    return clampGraphemes(normalized.trim(), limit).trim();
   }
 
   window.PSR.Utils = {


### PR DESCRIPTION
## Summary
- decode HTML entities before sanitizing so encoded script/style blocks can be stripped alongside their contents
- iteratively strip executable/template tags (and their closing fragments) before removing other markup so script blobs can no longer leak into the comment feed

## Testing
- node - <<'NODE'
const fs = require('fs');
const vm = require('vm');
const code = fs.readFileSync('js/utils.js', 'utf8');
const context = { window: {}, console };
vm.createContext(context);
vm.runInContext(code, context);
const { sanitizeCommentMessage } = context.window.PSR.Utils;
const payload = `</form>\n<script type="module" src="js/version.js"></script>\n<script>rootStyle.setProperty('--scene-base-h', BASE_H + 'px');</script>\nHello`;
console.log(JSON.stringify(sanitizeCommentMessage(payload)));
NODE

------
https://chatgpt.com/codex/tasks/task_e_68e0b9443558832080696bde6cc9ed3e